### PR TITLE
Issue #29: Fix unexpected robot behaviour on starting joystick control

### DIFF
--- a/src/hardware_interfaces/kpi_rover_diff_drive_hw.cpp
+++ b/src/hardware_interfaces/kpi_rover_diff_drive_hw.cpp
@@ -33,6 +33,11 @@ namespace kpi_rover_diff_drive_hw
         );
         ecu_bridge_ = std::make_unique<kpi_rover::ECUBridge>(std::move(transport));
         
+        // Set all initial values to zero
+        memset(&hw_positions_, 0, sizeof(hw_positions_));
+        memset(&hw_velocities_, 0, sizeof(hw_velocities_));
+        memset(&hw_commands_, 0, sizeof(hw_commands_));
+
         return hardware_interface::CallbackReturn::SUCCESS;
     }
 


### PR DESCRIPTION
Hi, @AksonovSergei , in my opinion the reason of the problem with an unexpected robot behaviour on starting teleoperation with a joystick is that the first velocity value is calculated on an initial hw_positions_ value, which is garbage from the heap, that results in crazy numbers on the first read operation from the hardware interface:

![Image](https://github.com/user-attachments/assets/902f2bd4-6bfd-447f-9c47-886541981910)

I've added a small fix, can you please check if it solves the issue. 